### PR TITLE
Show offline status

### DIFF
--- a/client/src/MessageInput.svelte
+++ b/client/src/MessageInput.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { SvelteComponent, createEventDispatcher } from "svelte"
-  import { user } from "./stores"
   import Input from "./ui/Input.svelte"
 
   const dispatch = createEventDispatcher()
   let messageBody = ""
   let messageElement: SvelteComponent
+  export let disabled: boolean
 </script>
 
 <div>
@@ -21,7 +21,7 @@
   >
     <Input
       multiline
-      disabled={!$user}
+      {disabled}
       maxRows={3}
       bind:value={messageBody}
       bind:this={messageElement}

--- a/client/src/Messages.svelte
+++ b/client/src/Messages.svelte
@@ -22,8 +22,13 @@
     messages.poll()
   })
 
+  const isOffline = derived(
+    messages,
+    ($messages) => $messages.connection === "offline",
+  )
+
   const displayMessages = derived(messages, ($messages) => {
-    return $messages
+    return $messages.list
       .sort((a, b) => Number(b.time) - Number(a.time)) // TODO: just use numbers!?
       .slice(0, showMessages)
       .reverse()
@@ -37,7 +42,7 @@
     showScrollToBottom =
       main.scrollHeight - main.offsetHeight > main.scrollTop + 300
     if (!isLoading && main.scrollTop <= main.scrollHeight / 10) {
-      const totalMessages = $messages.length - 1
+      const totalMessages = $messages.list.length - 1
       if (showMessages >= totalMessages) return
       isLoading = true
       setTimeout(() => {
@@ -87,6 +92,7 @@
 </main>
 
 <MessageInput
+  disabled={!$user || $isOffline}
   on:message={(e) => {
     handleNewMessage(e.detail)
     scrollToBottom()


### PR DESCRIPTION
I was testing by hand and realized that the behaviour around this is not very nice at the moment. Ultimately it might be useful to be all local-first and let you post a message even when you don't have a server connection, but we don't support that in our sync protocols yet.

I learned me some svelte!

I changed [the data type that the store returns](https://github.com/blaine/couloir/compare/client-tests...show-offline-status?expand=1#diff-e7f745c97194ac0812482a571b98ed6479b7301c9770aee521e73932e451a495R46) so that we can have the online/offline status in there too. WDYT? Is there a more idiomatic way to do this?