### PR TITLE
WIP: sync server <=> server

### DIFF
--- a/fake-server/src/app.ts
+++ b/fake-server/src/app.ts
@@ -117,5 +117,9 @@ export default async (dataPath: string) => {
     res.redirect("/")
   })
 
+  app.post("/sync", async (req, res) => {
+    res.send("ok")
+  })
+
   return app
 }


### PR DESCRIPTION
The idea here is to add a `/sync` endpoint that tells one server node to sync with another one, pulling and pushing messages as neccesary until the two `message-list`s are identical.